### PR TITLE
Remove pdf_view from default plugins

### DIFF
--- a/_etc/ckan/custom_options.ini
+++ b/_etc/ckan/custom_options.ini
@@ -1,5 +1,5 @@
 ## Plugins Settings
-ckan.plugins = datastore datapusher resource_proxy stats text_view recline_view pdf_view
+ckan.plugins = datastore datapusher resource_proxy stats text_view recline_view
 
 ## Datapusher settings
 ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet


### PR DESCRIPTION
When using CKAN 2.3, pdf_view prompts a misleading Postgres error if the pdf_view plugin is not separately installed.