### PR TITLE
Updates for CKAN 2.10

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,5 +1,5 @@
-FROM ckan/ckan-base:dev-v2.10
-#FROM ckan/ckan-base:2.9.7
+FROM ckan/ckan-base:ckan-2.10.0
+#FROM ckan/ckan-base:dev-v2.10
 
 # Set up environment variables
 ENV APP_DIR=/srv/app

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ckan/ckan-base:2.9.7-dev
+FROM ckan/ckan-base:ckan-2.10.0-dev
 
 
 # Set up environment variables


### PR DESCRIPTION
Use the new CKAN **2.10** (`ckan-2.10.0`) images from ckan-docker-base