### PR TITLE
Fix docker compose build on windows

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
 FROM postgres:12-alpine
 
 # Include extra setup scripts (eg datastore)
-ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/postgresql/docker-entrypoint-initdb.d/.gitattributes
+++ b/postgresql/docker-entrypoint-initdb.d/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
on windows, docker compose build and docker compose up breaks, because postgres does not import anything.

This PR fixes this by adjusting the gitattributes.

The shell scripts were configured to checkout as the user configured its local git. On windows, this often is "replace lf-by-crlf", which breaks docker builds in many occasions.