### PR TITLE
remove container_name?

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ To start the containers:
 
 See [CKAN Images](#ckan-images) for more details of what happens when using development mode.
 
+In dev mode, the `docker-compose.dev.yml` file intentionally excludes the specification of `container_names:`. This omission serves the purpose of facilitating the concurrent execution of multiple containers on the same host without necessitating updates to the container name for each project. For instance, duplicating the ckan-docker/ directory enables the simultaneous operation of more than one CKAN container.
+
+It is important to note that any container port that is configured to be mapped to the host will require the host port to be adjusted on a per-project basis. This adjustment is imperative to mitigate conflicts arising from port allocation.
+
 
 
 ##### Create an extension

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,6 @@ volumes:
 services:
 
   ckan-dev:
-    container_name: ${CKAN_CONTAINER_NAME}
     build:
       context: ckan/
       dockerfile: Dockerfile.dev
@@ -33,14 +32,12 @@ services:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
     
   datapusher:
-    container_name: ${DATAPUSHER_CONTAINER_NAME}
     image: ckan/ckan-base-datapusher:${DATAPUSHER_VERSION}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8800"]
 
   db:
-    container_name: ${POSTGRESQL_CONTAINER_NAME}
     build:
       context: postgresql/
     environment:
@@ -60,7 +57,6 @@ services:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
      
   solr:
-    container_name: ${SOLR_CONTAINER_NAME}
     image: ckan/ckan-solr:${SOLR_IMAGE_VERSION}
     volumes:
       - solr_data:/var/solr
@@ -69,7 +65,6 @@ services:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8983/solr/"]
 
   redis:
-    container_name: ${REDIS_CONTAINER_NAME}
     image: redis:${REDIS_VERSION}
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
For discussion: Removing the `container_name` lines lets us run many ckan-docker sites at the same time (assuming you use different ports)

What is the benefit in forcing a container name in the docker compose config?