### PR TITLE
PostgreSQL initialization files ownership

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
 FROM postgres:12-alpine
 
 # Include extra setup scripts (eg datastore)
-COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+COPY --chown=postgres:postgres docker-entrypoint-initdb.d /docker-entrypoint-initdb.d


### PR DESCRIPTION
Fixes: https://github.com/ckan/ckan-docker/issues/104

Adds `--chown` flag to `COPY` command in PostgreSQL Dockerfile to ensure that initialization files can be executed by `postgres` user.