### PR TITLE
docs: mention of ckan.ini in `docker compose` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ See [CKAN Images](#ckan-images) for more details of what happens when using deve
 
 You can use the ckan [extension](https://docs.ckan.org/en/latest/extensions/tutorial.html#creating-a-new-extension) instructions to create a CKAN extension, only executing the command inside the CKAN container and setting the mounted `src/` folder as output:
 
-    docker compose -f docker-compose.dev.yml exec ckan-dev /bin/sh -c "ckan generate extension --output-dir /srv/app/src_extensions"
-    
+    docker compose -f docker-compose.dev.yml exec ckan-dev /bin/sh -c "ckan -c /srv/app/ckan.ini generate extension --output-dir /srv/app/src_extensions"
+
 ![Screenshot 2023-02-22 at 1 45 55 pm](https://user-images.githubusercontent.com/54408245/220623568-b4e074c7-6d07-4d27-ae29-35ce70961463.png)
 
 


### PR DESCRIPTION
Without `-c /srv/app/ckan.ini`, not extension create interface would be available, and no error provided for a new user.