### PR TITLE
compose version is no longer used

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   ckan_storage:
   pg_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: "3"
-
-
 volumes:
   ckan_storage:
   pg_data:


### PR DESCRIPTION
Removes `version is obsolete` warning message.

See: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements