### PR TITLE
default datatables plugin instead of recline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@ NGINX_PORT=80
 NGINX_SSLPORT=443
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher"
+CKAN__PLUGINS="envvars image_view text_view datatables_view datastore datapusher"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
recline is unsupported and removed in ckan master