### PR TITLE
start dev ckan in parallel

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,13 +15,6 @@ services:
         - TZ=${TZ}
     env_file:
       - .env
-    depends_on:
-      db:
-        condition: service_healthy
-      solr:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     ports:
       - "0.0.0.0:${CKAN_PORT_HOST}:${CKAN_PORT}"
     volumes:


### PR DESCRIPTION
One day our ckan container might be fast enough to start using db/postgres/redis before they are ready. Today is not that day.

Starting the dev environment now launches the db, postgres and redis containers in parallel, waits for them all to be ready then launches the ckan container. This takes a while.
```
real    1m32.681s
user    0m20.008s
sys     0m0.333s
```
If we launch all containers in parallel we get a running ckan in much less time.
```
real    0m48.344s
user    0m8.595s
sys     0m0.186s
```
This could result in an error if ckan starts accessing the database too early, so this change has only been applied to the docker-compose.dev.yml file for now. For such a large improvement I think it's worth considering.

*FIXME* this could be made reliable by checking for the container status inside the ckan container.