### PR TITLE
volumes for installed files for faster startup

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,6 +27,8 @@ services:
     volumes:
       - ckan_storage:/var/lib/ckan
       - ./src:/srv/app/src_extensions
+      - /usr/lib/python3.10/site-packages
+      - /root/.vscode-server
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
         condition: service_healthy
     volumes:
       - ckan_storage:/var/lib/ckan
+      - /usr/lib/python3.10/site-packages
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]


### PR DESCRIPTION
Create volumes for python `site-packages` and `.vscode-server` (on dev) so that packages that are installed from requirements and vscode doesn't need to be re-downloaded and installed after every restart.