### PR TITLE
envvars last plugin in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@ NGINX_PORT=80
 NGINX_SSLPORT=443
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view datatables_view datastore datapusher"
+CKAN__PLUGINS="image_view text_view datatables_view datastore datapusher envvars"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
envvars should be last in the list of plugins so that other plugins can read/update the values it sets