### PR TITLE
remove broken, confusing CKAN_PORT setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,6 @@ USE_HTTPS_FOR_DEV=false
 CKAN_VERSION=2.10.0
 CKAN_SITE_ID=default
 CKAN_SITE_URL=https://localhost:8443
-CKAN_PORT=5000
-CKAN_PORT_HOST=5000
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME
 # See https://docs.ckan.org/en/latest/maintaining/configuration.html#api-token-settings
 CKAN___API_TOKEN__JWT__ENCODE__SECRET=string:CHANGE_ME

--- a/README.md
+++ b/README.md
@@ -248,9 +248,6 @@ ckan
 Add these lines to the `ckan-dev` service in the docker-compose.dev.yml file
 
 ```yaml
-ports:
-  - "0.0.0.0:${CKAN_PORT}:5000"
-
 stdin_open: true
 tty: true
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
       - solr
       - redis
     ports:
-      - "0.0.0.0:${CKAN_PORT_HOST}:${CKAN_PORT}"
+      - "0.0.0.0:${CKAN_PORT_HOST}:5000"
     volumes:
       - ckan_storage:/var/lib/ckan
       - ./src:/srv/app/src_extensions


### PR DESCRIPTION
changing the value of CKAN_PORT results in a broken environment because it's not passed to `ckan run`

Instead of passing `CKAN_PORT` to `ckan run` this PR removes the setting because there's no reason to change the port inside the container. `CKAN_PORT_HOST` allows changing the mapped port outside the container which is what users will care about.