### PR TITLE
Installing `patch` command in CKAN Dockerfile

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,6 +10,11 @@ COPY --chown=ckan-sys:ckan-sys docker-entrypoint.d/* /docker-entrypoint.d/
 # runtime mounted ones)
 COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches
 
+USER root
+
+# Install tool to make the below patch functionality work.
+RUN apt-get update && apt-get install -y patch
+
 USER ckan
 
 RUN for d in $APP_DIR/patches/*; do \


### PR DESCRIPTION
Just below the change I've made to CKAN/Dockerfile you'll see some code which copies in a directory of patch files and attempts to apply them. 

I attempted to make use of this functionality and found that the referenced `patch` tool isn't available inside the docker container; this PR ensures that it is installed.