### PR TITLE
Bump postgres to v16

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12-alpine
+FROM postgres:14-alpine
 
 # Include extra setup scripts (eg datastore)
 COPY --chown=postgres:postgres docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14-alpine
+FROM postgres:16-alpine
 
 # Include extra setup scripts (eg datastore)
 COPY --chown=postgres:postgres docker-entrypoint-initdb.d /docker-entrypoint-initdb.d


### PR DESCRIPTION
Postgres 12 EOL was November 2024. This PR bumps the base image to `postgres:16-alpine` (EOL November 9, 2028)