### PR TITLE
Update 01_setup_datapusher.sh

### DIFF
--- a/ckan/docker-entrypoint.d/01_setup_datapusher.sh
+++ b/ckan/docker-entrypoint.d/01_setup_datapusher.sh
@@ -1,12 +1,36 @@
 #!/bin/bash
 
-if [[ $CKAN__PLUGINS == *"datapusher"* ]]; then
-   # Datapusher settings have been configured in the .env file
-   # Set API token if necessary
-   if [ -z "$CKAN__DATAPUSHER__API_TOKEN" ] ; then
-      echo "Set up ckan.datapusher.api_token in the CKAN config file"
-      ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+if [[ "$CKAN__PLUGINS" == *"datapusher"* ]]; then
+   echo "[INFO] DataPusher plugin detected. Preparing token..."
+
+   # Wait until CKAN is responsive
+   echo "[INFO] Waiting for CKAN sysadmin user '$CKAN_SYSADMIN_NAME'..."
+   for i in {1..10}; do
+      if ckan -c "$CKAN_INI" user show "$CKAN_SYSADMIN_NAME" &> /dev/null; then
+         echo "[INFO] User $CKAN_SYSADMIN_NAME found."
+         break
+      fi
+      echo "[WAIT] Waiting... ($i/10)"
+      sleep 3
+   done
+
+   # Create sysadmin user if not found
+   if ! ckan -c "$CKAN_INI" user show "$CKAN_SYSADMIN_NAME" &> /dev/null; then
+      echo "[INFO] Creating user $CKAN_SYSADMIN_NAME..."
+      ckan -c "$CKAN_INI" sysadmin add "$CKAN_SYSADMIN_NAME" --force \
+           --email "${CKAN_SYSADMIN_EMAIL:-admin@example.com}" \
+           --password "${CKAN_SYSADMIN_PASSWORD:-pass123}"
+   fi
+
+   # Set the token
+   if [ -z "$CKAN__DATAPUSHER__API_TOKEN" ]; then
+      echo "[INFO] Generating DataPusher API token..."
+      token=$(ckan -c "$CKAN_INI" user token add "$CKAN_SYSADMIN_NAME" datapusher | tail -n 1 | tr -d '\r')
+      ckan config-tool "$CKAN_INI" "ckan.datapusher.api_token=${token}"
+      echo "[OK] Token applied."
+   else
+      echo "[INFO] CKAN__DATAPUSHER__API_TOKEN already set. Skipping token generation."
    fi
 else
-   echo "Not configuring DataPusher"
+   echo "[INFO] DataPusher plugin not enabled. Skipping setup."
 fi


### PR DESCRIPTION
## Fix CKAN crash on startup when using DataPusher plugin

CKAN was failing to start when the `datapusher` plugin was enabled because the startup script (`01_setup_datapusher.sh`) attempted to generate an API token for the plugin before the sysadmin user had been created.

The original script assumed that the user specified by `$CKAN_SYSADMIN_NAME` already existed, and used that user to create a token for `ckan.datapusher.api_token`. On fresh installations, this user may not yet exist, causing the token generation to fail and CKAN to crash with:

```
Exception: Config option `ckan.datapusher.api_token` must be set to use the DataPusher.
```

This commit updates the script to:
- Check if the sysadmin user exists using `ckan user show`
- If not, create the user using `ckan sysadmin add --force`
- Retry up to 10 times if the CKAN service is not ready yet
- Generate the DataPusher token only after the user exists
- Apply the token to the config using `ckan config-tool`

This makes the startup script more robust and ensures CKAN can successfully initialize with the DataPusher plugin enabled, even on a clean setup.