### PR TITLE
Specify platform for ARM emulation support

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,7 @@ volumes:
 services:
 
   ckan-dev:
+    platform: linux/amd64
     build:
       context: ckan/
       dockerfile: Dockerfile.dev

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,6 +39,7 @@ services:
       retries: 3
 
   datapusher:
+    platform: linux/amd64
     image: ckan/ckan-base-datapusher:${DATAPUSHER_VERSION}
     restart: unless-stopped
     healthcheck:
@@ -67,6 +68,7 @@ services:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
      
   solr:
+    platform: linux/amd64
     image: ckan/ckan-solr:${SOLR_IMAGE_VERSION}
     volumes:
       - solr_data:/var/solr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       retries: 3
     
   datapusher:
+    platform: linux/amd64
     networks:
       - ckannet
       - dbnet
@@ -86,6 +87,7 @@ services:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
      
   solr:
+    platform: linux/amd64
     networks:
       - solrnet
     image: ckan/ckan-solr:${SOLR_IMAGE_VERSION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - "0.0.0.0:${NGINX_SSLPORT_HOST}:${NGINX_SSLPORT}"
     
   ckan:
+    platform: linux/amd64
     build:
       context: ckan/
       dockerfile: Dockerfile


### PR DESCRIPTION
Close #249 

The current docker-compose files only work on amd64 due to the CKAN images only being available for amd64. Setting the platform to amd64 allows it to run under emulation for non-amd64 users.

This may require QEMU for non-Mac users (like the earlier user with the issue), should a note be added to the readme?

If the XLoader PRs get merged, they'll also need this change to their docker-compose files.