### PR TITLE
Add restart to nginx service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
         condition: service_healthy
     ports:
       - "0.0.0.0:${NGINX_SSLPORT_HOST}:${NGINX_SSLPORT}"
+    restart: unless-stopped
     
   ckan:
     platform: linux/amd64


### PR DESCRIPTION
Nginx service is missing `restart: unless-stopped` and it doesn't survive server reboots.